### PR TITLE
Release v1.1.0: AirPods Pro 2 support, new UI options & customizable notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ This project is a fully customizable Plasma widget designed to display the batte
     - AirPods Gen. 2
     - AirPods Gen. 3
     - AirPods Pro Gen. 1
+    - AirPods Pro Gen. 2
 
 - Partially Supported:
-    - AirPods Pro Gen. 2 and AirPods Gen. 4:
+    - AirPods Pro Gen. 3 and AirPods Gen. 4:
         - These devices are not fully recognized by the backend script. While the battery levels are displayed correctly, the model name may appear as "unknown."
         - You can manually update the title using the Appearance category in the widget settings.
 
-    - Not Supported:
-        - AirPods Max: This widget does not support AirPods Max.
+- Not Supported:
+    - AirPods Max: This widget does not support AirPods Max.
 
 # Setup Instructions
 
@@ -65,12 +66,13 @@ Autostart Backend Script (for Default Script)
 
 # Why Might the Title Be Unknown?
 
-If the AirPods model is not recognized (e.g., AirPods Pro Gen. 2 or AirPods Gen. 4), the widget will display the title as "unknown." This is because the backend script (based on AirStatus) currently distinguishes only between the following models:
+If the AirPods model is not recognized (e.g., AirPods Pro Gen. 3 or AirPods Gen. 4), the widget will display the title as "unknown." This is because the backend script (based on AirStatus) currently distinguishes only between the following models:
 
 - AirPods Gen. 1
 - AirPods Gen. 2
 - AirPods Gen. 3
 - AirPods Pro Gen. 1
+- AirPods Pro Gen. 2
 
 For newer or unsupported models, the backend script cannot identify the specific model, though battery levels will still be accurate.
 

--- a/airPodsBatteryWidget.notifyrc
+++ b/airPodsBatteryWidget.notifyrc
@@ -1,0 +1,9 @@
+[Global]
+IconName=headphone
+Comment=AirPods Battery Widget
+
+[Event/notification]
+Name=Battery Notification
+Comment=AirPods battery status
+Action=Popup|Sound
+Sound=message-new-instant.ogg

--- a/contents/config/config.qml
+++ b/contents/config/config.qml
@@ -26,4 +26,9 @@ ConfigModel {
         source: "config/ConfigIcons.qml"
     }
 
+    ConfigCategory {
+        name: i18n("Notification")
+        icon: "preferences-desktop-notification"
+        source: "config/ConfigNotification.qml"
+    }
 }

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -201,5 +201,58 @@
       <default>40</default>
     </entry>
   </group>
+  <group name="Notification">
+    <entry name="allowNotification" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="firstPodsNotificationSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="firstPodsIconSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="firstPodsUrgencySwitch" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="firstPodsBatteryLowSpin" type="Int">
+      <default>15</default>
+    </entry>
+    <entry name="secondPodsNotificationSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondPodsIconSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondPodsUrgencySwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondPodsBatteryLowSpin" type="Int">
+      <default>5</default>
+    </entry>
+    <entry name="firstCaseNotificationSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="firstCaseIconSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="firstCaseUrgencySwitch" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="firstCaseBatteryLowSpin" type="Int">
+      <default>40</default>
+    </entry>
+    <entry name="secondCaseNotificationSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondCaseIconSwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondCaseUrgencySwitch" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="secondCaseBatteryLowSpin" type="Int">
+      <default>20</default>
+    </entry>
+  </group>
 </kcfg>
 

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -28,8 +28,11 @@
     <entry name="customTimeThreshold" type="Int">
       <default>4</default>
     </entry>
-    <entry name="averageView" type="Bool">
+    <entry name="autoView" type="Bool">
       <default>true</default>
+    </entry>
+    <entry name="averageView" type="Bool">
+      <default>false</default>
     </entry>
     <entry name="detailedView" type="Bool">
       <default>false</default>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -40,6 +40,12 @@
     <entry name="showCaseBattery" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="autoHiddenCaseBattery" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="customTimeThreshold2" type="Int">
+      <default>2</default>
+    </entry>
     <entry name="doNotShowCaseBattery" type="Bool">
       <default>true</default>
     </entry>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -144,6 +144,9 @@
     <entry name="colorFullRepLU" type="string">
       <default>white</default>
     </entry>
+    <entry name="customDateFormat" type="string">
+      <default>yyyy-MM-dd hh:mm:ss</default>
+    </entry>
   </group>
   <group name="Icons">
     <entry name="autoWidgetIcons" type="Bool">

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -55,6 +55,12 @@
     <entry name="showAvailableCaseBatteryFullRep" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="autoHiddenCaseBatteryFullRep" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="customTimeThreshold3" type="Int">
+      <default>2</default>
+    </entry>
     <entry name="doNotShowCaseBatteryFullRep" type="Bool">
       <default>fasle</default>
     </entry>

--- a/contents/tools/Tools.js
+++ b/contents/tools/Tools.js
@@ -97,6 +97,11 @@ function fileExists(outPutFile) {
     }
 }
 
+// Function to check if the AirPods notification configuration file exists
+function existsNotifyrc() {
+    return fileExists('../../../../../knotifications6/airPodsBatteryWidget.notifyrc');
+}
+
 // Function to check if an auto-start configuration is set
 function isAutoStartSet() {
     return fileExists('../../../../../../../.config/autostart/run.sh.desktop');

--- a/contents/tools/Tools.js
+++ b/contents/tools/Tools.js
@@ -50,6 +50,21 @@ function getAirPodsModel() {
     return airPodsModel;
 }
 
+// Function to get the timestamp as date object
+function getDateObject(timestamp) {
+    var parts = timestamp.split(" "); // Split the string
+    var dateParts = parts[0].split("-"); // Split the date
+    var timeParts = parts[1].split(":"); // Split the time
+    return new Date(
+        dateParts[0],            // Year
+        dateParts[1] - 1,        // Month (0-based)
+        dateParts[2],            // Day
+        timeParts[0],            // Hours
+        timeParts[1],            // Minutes
+        timeParts[2]             // Seconds
+    );
+}
+
 // Function to get the timestamp of the last battery status update as raw string from backend
 function getLastUpdated() {
     return lastUpdated;
@@ -57,17 +72,7 @@ function getLastUpdated() {
 
 // Function to get the timestamp of the last battery status update as date object
 function getLastUpdatedDate() {
-    var parts = lastUpdated.split(" "); // Split the string
-    var dateParts = parts[0].split("-"); // Split the date
-    var timeParts = parts[1].split(":"); // Split the time
-    return new Date(
-        dateParts[0],            // Year
-        dateParts[1] - 1,        // Month (0-based)
-        dateParts[2],            // Day
-        timeParts[0],            // Hours
-        timeParts[1],            // Minutes
-        timeParts[2]             // Seconds
-    );
+    return getDateObject(lastUpdated);
 }
 
 // Function to get the timestamp of the last battery status update as raw string from backend
@@ -75,19 +80,9 @@ function getLastCaseUpdated() {
     return lastCaseUpdated;
 }
 
-// Function to get the timestamp of the last battery status update as date object
+// Function to get the timestamp of the last case battery status update as date object
 function getLastCaseUpdatedDate() {
-    var parts = lastCaseUpdated.split(" "); // Split the string
-    var dateParts = parts[0].split("-"); // Split the date
-    var timeParts = parts[1].split(":"); // Split the time
-    return new Date(
-        dateParts[0],            // Year
-        dateParts[1] - 1,        // Month (0-based)
-        dateParts[2],            // Day
-        timeParts[0],            // Hours
-        timeParts[1],            // Minutes
-        timeParts[2]             // Seconds
-    );
+    return getDateObject(lastCaseUpdated);
 }
 
 // Function to check if a specified file exists

--- a/contents/tools/Tools.js
+++ b/contents/tools/Tools.js
@@ -7,6 +7,7 @@ let caseCharge = -1;
 let isCaseCharging = false;
 let airPodsModel = "unknown";
 let lastUpdated = "2000-01-01 00:00:00";
+let lastCaseUpdated = "2000-01-01 00:00:00";
 let env = true;
 
 // Function to get the average charge of left and right AirPods
@@ -57,6 +58,26 @@ function getLastUpdated() {
 // Function to get the timestamp of the last battery status update as date object
 function getLastUpdatedDate() {
     var parts = lastUpdated.split(" "); // Split the string
+    var dateParts = parts[0].split("-"); // Split the date
+    var timeParts = parts[1].split(":"); // Split the time
+    return new Date(
+        dateParts[0],            // Year
+        dateParts[1] - 1,        // Month (0-based)
+        dateParts[2],            // Day
+        timeParts[0],            // Hours
+        timeParts[1],            // Minutes
+        timeParts[2]             // Seconds
+    );
+}
+
+// Function to get the timestamp of the last battery status update as raw string from backend
+function getLastCaseUpdated() {
+    return lastCaseUpdated;
+}
+
+// Function to get the timestamp of the last battery status update as date object
+function getLastCaseUpdatedDate() {
+    var parts = lastCaseUpdated.split(" "); // Split the string
     var dateParts = parts[0].split("-"); // Split the date
     var timeParts = parts[1].split(":"); // Split the time
     return new Date(
@@ -131,6 +152,7 @@ function updateBatteryStatus(outPutFile, refRawValue = "-1") {
 
                     // Update case charge only if it is a valid value (-1 means no data)
                     caseCharge = jsonData.charge.case == -1 ? caseCharge : jsonData.charge.case;
+                    lastCaseUpdated = jsonData.charge.case == -1 ? lastCaseUpdated : jsonData.date;
                     isCaseCharging = jsonData.charging_case;
 
                     airPodsModel = jsonData.model;

--- a/contents/ui/config/ConfigAppearance.qml
+++ b/contents/ui/config/ConfigAppearance.qml
@@ -41,6 +41,7 @@ Kirigami.ScrollablePage {
     readonly property alias cfg_italicFullRepLU: italicFullRepLU.checked
     readonly property alias cfg_fontSizeFullRepLU: fontSizeFullRepLU.value
     readonly property alias cfg_colorFullRepLU: colorFullRepLU.color
+    readonly property alias cfg_customDateFormat: customDateFormat.text
 
     Kirigami.FormLayout {
         anchors.fill: parent
@@ -532,6 +533,42 @@ Kirigami.ScrollablePage {
                     }
                 }
             }
+        }
+
+        // Displaying options for the date format label and preview
+        RowLayout {
+            Kirigami.FormData.label: i18n("Date format:")
+            visible: lastUpdateTextCheck.checked
+
+            Label {
+                Layout.fillWidth: true
+                textFormat: Text.PlainText
+                text: Qt.locale().toString(new Date(), customDateFormat.text);
+            }
+        }
+
+        // Entering a custom date format
+        TextField {
+            id: customDateFormat
+            Layout.fillWidth: true
+            visible: lastUpdateTextCheck.checked
+        }
+
+        // Label with a clickable link to Qt's time format documentation
+        Label {
+            text: i18n("<a href=\"https://doc.qt.io/qt-6/qml-qtqml-qt.html#formatDateTime-method\">Time Format Documentation</a>")
+            visible: lastUpdateTextCheck.checked
+
+            wrapMode: Text.Wrap
+
+            Layout.preferredWidth: Layout.maximumWidth
+            Layout.maximumWidth: Kirigami.Units.gridUnit * 16
+
+            HoverHandler {
+                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : undefined
+            }
+
+            onLinkActivated: link => Qt.openUrlExternally(link)
         }
     }
 }

--- a/contents/ui/config/ConfigBehavior.qml
+++ b/contents/ui/config/ConfigBehavior.qml
@@ -26,10 +26,10 @@ Kirigami.ScrollablePage {
     readonly property alias cfg_doNotShowCaseBatteryFullRep: doNotShowCaseBatteryFullRep.checked
 
     Kirigami.FormLayout {
-        // Section for general widget behavior settings
+        // Section for control panel view settings
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Generale Wight Behavior")
+            Kirigami.FormData.label: i18n("Control Panel View")
         }
 
         // Checkbox to hide the widget when Bluetooth is off
@@ -59,10 +59,22 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Section for control panel view settings
+        // Inline message shown when the widget is hidden or recently updated
+        Kirigami.InlineMessage {
+            visible: hiddenWidgetBt.checked || hiddenWidgetLastUpdate.checked
+            text: i18n("Note: The widget will always show in Plasma edit mode.")
+            anchors.left: parent.left
+            anchors.right: parent.right
+            font.pixelSize: 12
+            font.bold: true
+        }
+
         Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Control Panel View")
+            Kirigami.FormData.isSection: false
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: false
         }
 
         // Column layout for AirPods panel display options

--- a/contents/ui/config/ConfigBehavior.qml
+++ b/contents/ui/config/ConfigBehavior.qml
@@ -21,6 +21,8 @@ Kirigami.ScrollablePage {
 
     readonly property alias cfg_showAlwaysCaseBatteryFullRep: showAlwaysCaseBatteryFullRep.checked
     readonly property alias cfg_showAvailableCaseBatteryFullRep: showAvailableCaseBatteryFullRep.checked
+    readonly property alias cfg_autoHiddenCaseBatteryFullRep: autoHiddenCaseBatteryFullRep.checked
+    readonly property alias cfg_customTimeThreshold3: customTimeThreshold3.value
     readonly property alias cfg_doNotShowCaseBatteryFullRep: doNotShowCaseBatteryFullRep.checked
 
     Kirigami.FormLayout {
@@ -164,21 +166,63 @@ Kirigami.ScrollablePage {
             RadioButton {
                 id: showAlwaysCaseBatteryFullRep
                 text: i18n("Always show case battery level")
-                checked: !doNotShowCaseBatteryFullRep.checked && !showAvailableCaseBatteryFullRep.checked
+                onToggled: {
+                    showAvailableCaseBatteryFullRep.checked = false
+                    autoHiddenCaseBatteryFullRep.checked = false;
+                    doNotShowCaseBatteryFullRep.checked = false;
+                }
             }
         
             // Radio button to show the last available battery level of the case
             RadioButton {
                 id: showAvailableCaseBatteryFullRep
                 text: i18n("Show last available battery level of the case")
-                checked: !doNotShowCaseBatteryFullRep.checked && !showAlwaysCaseBatteryFullRep.checked
+                onToggled: {
+                    showAlwaysCaseBatteryFullRep.checked = false
+                    autoHiddenCaseBatteryFullRep.checked = false;
+                    doNotShowCaseBatteryFullRep.checked = false;
+                }
+            }
+
+            RowLayout {
+                // Radio button to hide the case battery after a custom time
+                RadioButton {
+                    id: autoHiddenCaseBatteryFullRep
+                    text: i18n("Hide the case battery after")
+                    onToggled: {
+                        showAlwaysCaseBatteryFullRep.checked = false
+                        showAvailableCaseBatteryFullRep.checked = false;
+                        doNotShowCaseBatteryFullRep.checked = false;
+                    }
+
+                    ToolTip {
+                        text: i18n("The last available battery level of the case will be hidden after " + customTimeThreshold3.value + (customTimeThreshold3.value == 1 ? " hour." : " hours."))
+                    }
+                }
+
+                // SpinBox to select the custom time threshold (in hours)
+                SpinBox {
+                    id: customTimeThreshold3
+                    enabled: autoHiddenCaseBatteryFullRep.checked
+                    from: 1
+                    to: 24
+                    stepSize: 1
+                }
+
+                Label {
+                    text: i18n(customTimeThreshold3.value == 1 ? " hour." : " hours.")
+                }
             }
         
             // Radio button to hide the case battery level
             RadioButton {
                 id: doNotShowCaseBatteryFullRep
                 text: i18n("Don't show case battery level")
-                checked: !showAlwaysCaseBatteryFullRep.checked && !showAvailableCaseBatteryFullRep.checked
+                onToggled: {
+                    showAvailableCaseBatteryFullRep.checked = false
+                    autoHiddenCaseBatteryFullRep.checked = false;
+                    showAlwaysCaseBatteryFullRep.checked = false;
+                }
             }
         }
     }

--- a/contents/ui/config/ConfigBehavior.qml
+++ b/contents/ui/config/ConfigBehavior.qml
@@ -10,6 +10,7 @@ Kirigami.ScrollablePage {
     readonly property alias cfg_hiddenWidgetLastUpdate: hiddenWidgetLastUpdate.checked
     readonly property alias cfg_customTimeThreshold: customTimeThreshold.value
 
+    readonly property alias cfg_autoView: autoView.checked
     readonly property alias cfg_averageView: averageView.checked
     readonly property alias cfg_detailedView: detailedView.checked
     readonly property alias cfg_showCaseBattery: showCaseBattery.checked
@@ -62,6 +63,13 @@ Kirigami.ScrollablePage {
         // Column layout for AirPods panel display options
         ColumnLayout {
             Kirigami.FormData.label: i18n("AirPods panel display option:")
+
+            // Radio button for switching between average battery level of both AirPods and individual battery levels
+            RadioButton {
+                id: autoView
+                text: i18n("Automatic switching between average <br> battery level of both AirPods and <br> individual battery levels")
+                checked: !averageView.checked
+            }
 
             // Radio button for showing the average battery level of both AirPods
             RadioButton {

--- a/contents/ui/config/ConfigBehavior.qml
+++ b/contents/ui/config/ConfigBehavior.qml
@@ -13,7 +13,10 @@ Kirigami.ScrollablePage {
     readonly property alias cfg_autoView: autoView.checked
     readonly property alias cfg_averageView: averageView.checked
     readonly property alias cfg_detailedView: detailedView.checked
+
     readonly property alias cfg_showCaseBattery: showCaseBattery.checked
+    readonly property alias cfg_autoHiddenCaseBattery: autoHiddenCaseBattery.checked
+    readonly property alias cfg_customTimeThreshold2: customTimeThreshold2.value
     readonly property alias cfg_doNotShowCaseBattery: doNotShowCaseBattery.checked
 
     readonly property alias cfg_showAlwaysCaseBatteryFullRep: showAlwaysCaseBatteryFullRep.checked
@@ -50,7 +53,7 @@ Kirigami.ScrollablePage {
                 stepSize: 1
             }
             PC3.Label {
-                text: customTimeThreshold.value + " hours"
+                text: i18n(customTimeThreshold.value + (customTimeThreshold.value == 1 ? " hour." : " hours."))
             }
         }
 
@@ -85,6 +88,14 @@ Kirigami.ScrollablePage {
             }
         }
 
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: false
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: false
+        }
+
         // Column layout for AirPods case panel display options
         ColumnLayout{
             Kirigami.FormData.label: i18n("AirPods case panel display option:")
@@ -93,13 +104,49 @@ Kirigami.ScrollablePage {
             RadioButton {
                 id: showCaseBattery
                 text: i18n("Show last available battery level of the case")
-                checked: !doNotShowCaseBattery.checked
+                onToggled: {
+                    autoHiddenCaseBattery.checked = false;
+                    doNotShowCaseBattery.checked = false;
+                }
+            }
+
+            RowLayout {
+                // Radio button to hide the case battery after a custom time
+                RadioButton {
+                    id: autoHiddenCaseBattery
+                    text: i18n("Hide the case battery after")
+                    onToggled: {
+                        showCaseBattery.checked = false;
+                        doNotShowCaseBattery.checked = false;
+                    }
+
+                    ToolTip {
+                        text: i18n("The last available battery level of the case will be hidden after " + customTimeThreshold2.value + (customTimeThreshold2.value == 1 ? " hour." : " hours."))
+                    }
+                }
+
+                // SpinBox to select the custom time threshold (in hours)
+                SpinBox {
+                    id: customTimeThreshold2
+                    enabled: autoHiddenCaseBattery.checked
+                    from: 1
+                    to: 24
+                    stepSize: 1
+                }
+
+                Label {
+                    text: i18n(customTimeThreshold2.value == 1 ? " hour." : " hours.")
+                }
             }
 
             // Radio button to hide the case battery level
             RadioButton {
                 id: doNotShowCaseBattery
                 text: i18n("Don't show case battery level")
+                onToggled: {
+                    showCaseBattery.checked = false;
+                    autoHiddenCaseBattery.checked = false;
+                }
             }
         }
 

--- a/contents/ui/config/ConfigGeneral.qml
+++ b/contents/ui/config/ConfigGeneral.qml
@@ -236,11 +236,15 @@ Kirigami.ScrollablePage {
 
     // Timer to monitor the output generation by the backend script
     Timer {
+        id: timer
         interval: 600
         running: true
         repeat: true
         onTriggered: {
             wait.visible = (!Tools.fileExists("../../airstatus.out") && widgetScript.checked && !widgetScriptMessage.visible);
+            if (!wait.visible) {
+                timer.running = timer.repeat = false;
+            }
         }
     }
 }

--- a/contents/ui/config/ConfigGeneral.qml
+++ b/contents/ui/config/ConfigGeneral.qml
@@ -155,6 +155,15 @@ Kirigami.ScrollablePage {
             icon.source: "dialog-positive"
         }
 
+        // Information for optional configuration in the widget's notification section
+        Kirigami.InlineMessage {
+            visible: finishBackendSetupMessage.visible && cfg.allowNotification && !Tools.existsNotifyrc()
+            anchors.left: root.left
+            anchors.right: root.right
+            text: i18n("Optional configuration: You can adjust additional configurations in the widget's notification section.")
+            font.pixelSize: 12
+        }
+
         // Information to wait for the initial output
         Kirigami.InlineMessage {
             id: wait

--- a/contents/ui/config/ConfigNotification.qml
+++ b/contents/ui/config/ConfigNotification.qml
@@ -1,0 +1,659 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+import Qt.labs.folderlistmodel 2.1
+
+import org.kde.kirigami as Kirigami
+import org.kde.notification 1.0
+import org.kde.plasma.components as PC3
+import org.kde.plasma.plasmoid 2.0
+
+import "../../tools/Tools.js"       as Tools
+
+Kirigami.ScrollablePage {
+    readonly property var cfg: plasmoid.configuration
+
+    // Define paths for icons
+    property string iconBasePath:       "../../images/" + (cfg.autoWidgetIcons ? cfg.comboBoxDefaultIconSelect : cfg.iconSelect)
+    property string averageIconPath:    iconBasePath + "/airpods.png"
+    property string leftIconPath:       iconBasePath + "/airpod-left.png"
+    property string rightIconPath:      iconBasePath + "/airpod-right.png"
+    property string caseIconPath:       iconBasePath + "/airpods-case.png"
+
+    readonly property alias cfg_allowNotification: allowNotification.checked
+
+    readonly property alias cfg_firstPodsNotificationSwitch: firstPodsNotificationSwitch.checked
+    readonly property alias cfg_firstPodsIconSwitch: firstPodsIconSwitch.checked
+    readonly property alias cfg_firstPodsUrgencySwitch: firstPodsUrgencySwitch.checked
+    readonly property alias cfg_firstPodsBatteryLowSpin: firstPodsBatteryLowSpin.value
+
+    readonly property alias cfg_secondPodsNotificationSwitch: secondPodsNotificationSwitch.checked
+    readonly property alias cfg_secondPodsIconSwitch: secondPodsIconSwitch.checked
+    readonly property alias cfg_secondPodsUrgencySwitch: secondPodsUrgencySwitch.checked
+    readonly property alias cfg_secondPodsBatteryLowSpin: secondPodsBatteryLowSpin.value
+
+    readonly property alias cfg_firstCaseNotificationSwitch: firstCaseNotificationSwitch.checked
+    readonly property alias cfg_firstCaseIconSwitch: firstCaseIconSwitch.checked
+    readonly property alias cfg_firstCaseUrgencySwitch: firstCaseUrgencySwitch.checked
+    readonly property alias cfg_firstCaseBatteryLowSpin: firstCaseBatteryLowSpin.value
+
+    readonly property alias cfg_secondCaseNotificationSwitch: secondCaseNotificationSwitch.checked
+    readonly property alias cfg_secondCaseIconSwitch: secondCaseIconSwitch.checked
+    readonly property alias cfg_secondCaseUrgencySwitch: secondCaseUrgencySwitch.checked
+    readonly property alias cfg_secondCaseBatteryLowSpin: secondCaseBatteryLowSpin.value    
+
+
+    // Function to set the description of a notification dynamically
+    function setNotificationDescription(id, notificationSwitch, batteryLowSpin, urgencySwitch, iconSwitch) {
+        notificationModel.setProperty(id, "description", (notificationSwitch.checked ? "On, below "
+                + (batteryLowSpin.value +"%")
+                + (notificationSwitch.checked && urgencySwitch.checked ? ", urgent" : "")
+                + (notificationSwitch.checked && iconSwitch.checked ? ", show icon" : "")
+                : "Off"))
+    }
+
+    // Function to send a battery level notification for AirPods or the case
+    function sendBatteryNotification(name, batteryLowSpin, iconSwitch, iconPath, urgencySwitch) {
+        return sendNotification(name + " battery level low ("+ batteryLowSpin +"%)", "", iconSwitch ? Qt.resolvedUrl(iconPath).toString().split("file://")[1] : "/", urgencySwitch ? "CriticalUrgency" : "NormalUrgency");
+    }
+
+    // Generic function to send a notification
+    function sendNotification(title = "", text = "", iconName = "/", urgency = "NormalUrgency") {
+        var notification = notificationComponent.createObject(parent);
+        notification.title = title;
+        notification.text = text;
+        notification.iconName = iconName;
+        notification.urgency = urgency;
+        notification.sendEvent();
+        return notification;
+    }
+
+    Kirigami.FormLayout {
+        id: root
+
+        // Separator to organize sections within the form
+        Kirigami.Separator {
+            anchors.left: root.left
+            anchors.right: root.right
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Widget Notification")
+        }
+   
+        // Card container for settings
+        Kirigami.AbstractCard {
+            anchors.left: root.left
+            anchors.right: root.right
+            contentItem: Item {
+                implicitWidth: settingsLayout.implicitWidth
+                implicitHeight: settingsLayout.implicitHeight
+
+                // Layout for settings content
+                GridLayout {
+                    id: settingsLayout
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+
+                    // Section heading
+                    Kirigami.Heading {
+                        Layout.fillWidth: true
+                        level: 1
+                        text: i18n("Enable notifications")
+                    }
+
+                    // Switch to enable/disable notifications
+                    Switch {
+                        id: allowNotification   
+                        Layout.alignment: Qt.AlignRight
+                        Layout.columnSpan: 2
+                    }
+                }
+            }
+        }
+
+        // FolderListModel for knotifications6
+        FolderListModel {
+            id: knotificationsModel
+            folder: Qt.resolvedUrl("../../../../../../knotifications6/")
+        }
+
+        // Warning message for optional notification configuration
+        Kirigami.InlineMessage {
+            id: widgetScriptMessage
+            visible: allowNotification.checked && !Tools.existsNotifyrc()
+            anchors.left: root.left
+            anchors.right: root.right
+            text: i18n( "The widget uses the Plasma Workspace for the notification frame. "
+                    +   "Change the notification frame to the individual widget notification frame for a better look and feel, and to access individual notification settings for this widget in the System Settings menu."
+                    +   "<ol>"
+                    +   (!String(knotificationsModel.parentFolder).includes("/.local/share") ?
+                        ("<li>Open the <b>~/.local/share/</b> folder.</li>"
+                    +   "<li>Create a new folder named <b>knotifications6</b> inside <b>~/.local/share/</b>.</li>") :
+                        ("<li>Open the existing <b>knotifications6</b> folder:<br>"
+                    +   "<b>~/.local/share/knotifications6</b></li>"))
+                    +   "<li>Open the widget source folder:<br>"
+                    +   "<b>~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend</b></li>"
+                    +   "<li>Copy the <b>airPodsBatteryWidget.notifyrc</b> file from the widget source folder into the <b>knotifications6</b> folder.</li>"
+                    +   "</ol>")
+            font.pixelSize: 13
+            type: Kirigami.MessageType.Warning
+            actions: [
+                // Button to open knotifications6 folder
+                Kirigami.Action {
+                    visible: String(knotificationsModel.parentFolder).includes("/.local/share")
+                    text: qsTr("Open knotifications6")
+                    icon.name: "document-open-folder"
+                    onTriggered: {
+                        var scriptPath = Qt.resolvedUrl("../../../../../../knotifications6")
+                        Qt.openUrlExternally(scriptPath)
+                    }
+                },
+                // Button to ~/.local/share folder
+                Kirigami.Action {
+                    visible: !String(knotificationsModel.parentFolder).includes("/.local/share")
+                    text: qsTr("Open ~/.local/share")
+                    icon.name: "document-open-folder"
+                    onTriggered: {
+                        var scriptPath = Qt.resolvedUrl("../../../../../../")
+                        Qt.openUrlExternally(scriptPath)
+                    }
+                },
+                // Button to open folder widget folder
+                Kirigami.Action {
+                    text: qsTr("Open source folder")
+                    icon.name: "document-open-folder"
+                    onTriggered: {
+                        var scriptPath = Qt.resolvedUrl("../../../")
+                        Qt.openUrlExternally(scriptPath)
+                    }
+                }
+            ]
+        }
+    
+        Kirigami.ScrollablePage {
+            anchors.left: root.left
+            anchors.right: root.right
+            visible: allowNotification.checked
+            
+            // Background for a card or container with theme-based color and rounded corners
+            background: Rectangle {
+                color: Kirigami.Theme.backgroundColor
+                radius: 12
+            }
+
+            // List view for card elements
+            Kirigami.CardsListView {
+                id: cardsView
+                // Model contains info to be displayed
+                model: notificationModel
+                // Delegate is how the information will be presented in the ListView
+                delegate: notificationDelegate
+            }
+
+            // ListModel needed for ListView, contains elements to be displayed
+            ListModel {
+                id: notificationModel
+
+                // Entry for the first AirPods notification
+                ListElement {
+                    name: "First Airpods notification"
+                    description: "" 
+                }
+
+                // Entry for the second AirPods notification
+                ListElement {
+                    name: "Second Airpods notification"
+                    description: "" 
+                }
+
+                // Entry for the first Case notification
+                ListElement {
+                    name: "First Case notification"
+                    description: "" 
+                }
+
+                // Entry for the second Case notification
+                ListElement {
+                    name: "Second Case notification"
+                    description: "" 
+                }
+            }
+
+            // Delegate Component used by a ListView to define how each item in the list is displayed
+            Component {
+                id: notificationDelegate
+
+                // Card representing a single notification in the ListView
+                Kirigami.AbstractCard {
+                    contentItem: Item {
+                        implicitWidth: delegateLayoutCard.implicitWidth
+                        implicitHeight: delegateLayoutCard.implicitHeight
+
+                        // Layout for the content inside the card
+                        GridLayout {
+                            id: delegateLayoutCard
+                            anchors.left: parent.left
+                            anchors.top: parent.top
+                            anchors.right: parent.right
+                            
+                            // Column for text elements
+                            ColumnLayout {
+                                // Heading for the notification name
+                                Kirigami.Heading {
+                                    Layout.fillWidth: true
+                                    level: 2
+                                    text: name
+                                }
+
+                                // Horizontal rule
+                                Kirigami.Separator {
+                                    Layout.fillWidth: true
+                                    visible: description.length > 0
+                                }
+
+                                // Label displaying the description of the notification
+                                Label {
+                                    Layout.fillWidth: true
+                                    text: description
+                                }
+                            }
+
+                            // Button to edit the notification
+                            Button {
+                                Layout.alignment: Qt.AlignRight
+                                Layout.columnSpan: 2
+                                text: i18n("Edit")
+
+                                // Open the corresponding dialog when clicked
+                                onClicked: {
+                                    switch(name) {
+                                        case "First Airpods notification":
+                                            firstPodsDialog.open()
+                                        break;
+                                        case "Second Airpods notification":
+                                            secondPodsDialog.open()
+                                        break;
+                                        case "First Case notification":
+                                            firstCaseDialog.open()
+                                        break;
+                                        case "Second Case notification":
+                                            secondCaseDialog.open()
+                                        break;
+                                    }
+                                }
+                            }
+                        }   
+                    }
+                }
+            }
+
+            // Initialize descriptions for each notification in the ListModel
+            Component.onCompleted: {
+                setNotificationDescription(0, firstPodsNotificationSwitch, firstPodsBatteryLowSpin, firstPodsUrgencySwitch, firstPodsIconSwitch)
+                setNotificationDescription(1, secondPodsNotificationSwitch, secondPodsBatteryLowSpin, secondPodsUrgencySwitch, secondPodsIconSwitch)
+                setNotificationDescription(2, firstCaseNotificationSwitch, firstCaseBatteryLowSpin, firstCaseUrgencySwitch, firstCaseIconSwitch)
+                setNotificationDescription(3, secondCaseNotificationSwitch, secondCaseBatteryLowSpin, secondCaseUrgencySwitch, secondCaseIconSwitch)
+            }
+
+            // Dialog to configure the first AirPods notification
+            Dialog {
+                id: firstPodsDialog
+                title: "Setup first Airpods notification"
+                modal: true
+                standardButtons: Dialog.Ok | Dialog.Cancel
+                width: 440
+                height: 280
+
+                ColumnLayout {
+                    spacing: 20
+                    Kirigami.FormLayout {
+                        // Enable or disable the first AirPods notification
+                        Switch {
+                            id: firstPodsNotificationSwitch
+                            Kirigami.FormData.label: i18n("Enable first Airpods notification")
+                        }
+
+                        // Show icon in notification
+                        Switch {
+                            id: firstPodsIconSwitch
+                            enabled: firstPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Show the AirPods icon in the notification")
+                        }
+
+                        // Mark notification as urgent
+                        Switch {
+                            id: firstPodsUrgencySwitch
+                            enabled: firstPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Mark notification as urgent")
+                        }
+
+                        // SpinBox to set the battery threshold for triggering the notification
+                        SpinBox {
+                            id: firstPodsBatteryLowSpin
+                            enabled: firstPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Trigger notification when battery is below:")
+                            from: secondPodsNotificationSwitch.checked ? secondPodsBatteryLowSpin.value : 0
+                            to: 100
+                            stepSize: 5
+
+                            // Ensure first notification is always higher than the second one
+                            onValueModified: {
+                                if (secondPodsNotificationSwitch.checked && firstPodsBatteryLowSpin.value <= secondPodsBatteryLowSpin.value) {
+                                    errorMessagesLabel1.visible = true;
+                                    firstPodsBatteryLowSpin.value = firstPodsBatteryLowSpin.value + 5;
+                                } else {
+                                    errorMessagesLabel1.visible = false;
+                                    startTimer.running = false;
+                                }
+                            }
+                        }
+
+                        // Error message if first notification threshold is not higher than second
+                        Label {
+                            id: errorMessagesLabel1
+                            visible: false
+                            anchors.left: parent.left
+                            text: i18n("First notification must be higher than the second one.")
+                            color: "red"
+                            font.bold: true
+
+                            // Start timer when error becomes visible (used for UI feedback)
+                            onVisibleChanged: {
+                                startTimer.running = true;
+                            }
+                        }
+                    }
+
+                    // Button to send a test notification for the first AirPods
+                    Button {
+                        text: "Send test notification"
+                        enabled: firstPodsNotificationSwitch.checked
+                        onClicked: {
+                            sendBatteryNotification("AirPods", firstPodsBatteryLowSpin.value, firstPodsIconSwitch.checked, averageIconPath, firstPodsUrgencySwitch.checked);
+                        }
+                    }
+                }
+
+                // Update the ListModel description when the dialog is accepted
+                onAccepted: {
+                    setNotificationDescription(0, firstPodsNotificationSwitch, firstPodsBatteryLowSpin, firstPodsUrgencySwitch, firstPodsIconSwitch);
+                }
+            }
+
+            // Dialog to configure the second AirPods notification
+            Dialog {
+                id: secondPodsDialog
+                title: "Setup second Airpods notification"
+                modal: true
+                standardButtons: Dialog.Ok | Dialog.Cancel
+                width: 440
+                height: 280
+
+                ColumnLayout {
+                    spacing: 20
+                    Kirigami.FormLayout {
+                        // Enable or disable the second AirPods notification
+                        Switch {
+                            id: secondPodsNotificationSwitch
+                            Kirigami.FormData.label: i18n("Enable second Airpods notification")
+                        }
+
+                        // Show icon in notification
+                        Switch {
+                            id: secondPodsIconSwitch
+                            enabled: secondPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Show the AirPods icon in the notification")
+                        }            
+
+                        // Mark notification as urgent
+                        Switch {
+                            id: secondPodsUrgencySwitch
+                            enabled: secondPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Mark notification as urgent")
+                        }
+
+                        // SpinBox to set the battery threshold for triggering the notification
+                        SpinBox {
+                            id: secondPodsBatteryLowSpin
+                            enabled: secondPodsNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Trigger notification when battery is below:")
+                            from: 0
+                            to: firstPodsNotificationSwitch.checked ? firstPodsBatteryLowSpin.value : 100
+                            stepSize: 5
+
+                            // Ensure second notification is always higher than the second one
+                            onValueModified: {
+                                if (firstPodsNotificationSwitch.checked && secondPodsBatteryLowSpin.value >= firstPodsBatteryLowSpin.value) {
+                                    errorMessagesLabel2.visible = true;
+                                    secondPodsBatteryLowSpin.value = secondPodsBatteryLowSpin.value - 5;
+                                } else {
+                                    errorMessagesLabel2.visible = false;
+                                    startTimer.running = false;
+                                }
+                            }
+                        }
+
+                        // Error message if second notification threshold is higher than first
+                        Label {
+                            id: errorMessagesLabel2
+                            visible: false
+                            anchors.left: parent.left
+                            text: i18n("Second notification must be lower than the first one.")
+                            color: "red"
+                            font.bold: true
+
+                            // Start timer when error becomes visible (used for UI feedback)
+                            onVisibleChanged: {
+                                startTimer.running = true;
+                            }
+                        }
+                    }
+
+                    // Button to send a test notification for the second AirPods
+                    Button {
+                        text: "Send test notification"
+                        enabled: secondPodsNotificationSwitch.checked
+                        onClicked: {
+                            sendBatteryNotification("AirPods", secondPodsBatteryLowSpin.value, secondPodsIconSwitch.checked, averageIconPath, secondPodsUrgencySwitch.checked);
+                        }
+                    }
+                }
+
+                // Update the ListModel description when the dialog is accepted
+                onAccepted: {
+                    setNotificationDescription(1, secondPodsNotificationSwitch, secondPodsBatteryLowSpin, secondPodsUrgencySwitch, secondPodsIconSwitch);
+                }
+            }
+
+            // Dialog to configure the first AirPods case notification
+            Dialog {
+                id: firstCaseDialog
+                title: "Setup first Case notification"
+                modal: true
+                standardButtons: Dialog.Ok | Dialog.Cancel
+                width: 440
+                height: 280
+
+                ColumnLayout {
+                    spacing: 20
+                    Kirigami.FormLayout {
+                        // Enable or disable the first AirPods case notification
+                        Switch {
+                            id: firstCaseNotificationSwitch
+                            Kirigami.FormData.label: i18n("Enable first Case notification")
+                        }
+                        
+                        // Show icon in notification
+                        Switch {
+                            id: firstCaseIconSwitch
+                            enabled: firstCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Show the Case icon in the notification")
+                        }            
+
+                        // Mark notification as urgent
+                        Switch {
+                            id: firstCaseUrgencySwitch
+                            enabled: firstCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Mark notification as urgent")
+                        }
+
+                        // SpinBox to set the battery threshold for triggering the notification
+                        SpinBox {
+                            id: firstCaseBatteryLowSpin
+                            enabled: firstCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Trigger notification when battery is below:")
+                            from: secondCaseNotificationSwitch.checked ? secondCaseBatteryLowSpin.value : 0
+                            to: 100
+                            stepSize: 5
+
+                            // Ensure first notification is always higher than the second one
+                            onValueModified: {
+                                if (secondCaseNotificationSwitch.checked && firstCaseBatteryLowSpin.value <= secondCaseBatteryLowSpin.value) {
+                                    errorMessagesLabel3.visible = true;
+                                    firstCaseBatteryLowSpin.value = firstCaseBatteryLowSpin.value + 5;
+                                } else {
+                                    errorMessagesLabel3.visible = false;
+                                    startTimer.running = false;
+                                }
+                            }
+                        }
+                        
+                        // Error message if first notification threshold is not higher than second
+                        Label {
+                            id: errorMessagesLabel3
+                            visible: false
+                            anchors.left: parent.left
+                            text: i18n("First case notification must be higher than the second one.")
+                            color: "red"
+                            font.bold: true
+
+                            // Start timer when error becomes visible (used for UI feedback)
+                            onVisibleChanged: {
+                                startTimer.running = true;
+                            }
+                        }
+                    }
+
+                    // Button to send a test notification for the first AirPods case
+                    Button {
+                        text: "Send test notification"
+                        enabled: firstCaseNotificationSwitch.checked
+                        onClicked: {
+                            sendBatteryNotification("AirPods Case", firstCaseBatteryLowSpin.value, firstCaseIconSwitch.checked, caseIconPath, firstCaseUrgencySwitch.checked);
+                        }
+                    }
+                }
+
+                // Update the ListModel description when the dialog is accepted
+                onAccepted: {
+                    setNotificationDescription(2, firstCaseNotificationSwitch, firstCaseBatteryLowSpin, firstCaseUrgencySwitch, firstCaseIconSwitch);
+                }
+            }
+
+            // Dialog to configure the second AirPods case notification
+            Dialog {
+                id: secondCaseDialog
+                title: "Setup second case notification"
+                modal: true
+                standardButtons: Dialog.Ok | Dialog.Cancel
+                width: 440
+                height: 280
+
+                ColumnLayout {
+                    spacing: 20
+                    Kirigami.FormLayout {
+                        // Enable or disable the second AirPods case notification
+                        Switch {
+                            id: secondCaseNotificationSwitch
+                            Kirigami.FormData.label: i18n("Enable second Case notification")
+                        }
+
+                        // Show icon in notification
+                        Switch {
+                            id: secondCaseIconSwitch
+                            enabled: secondCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Show the Case icon in the notification")
+                        }            
+
+                        // Mark notification as urgent
+                        Switch {
+                            id: secondCaseUrgencySwitch
+                            enabled: secondCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Mark notification as urgent")
+                        }
+
+                        // SpinBox to set the battery threshold for triggering the notification
+                        SpinBox {
+                            id: secondCaseBatteryLowSpin
+                            enabled: secondCaseNotificationSwitch.checked
+                            Kirigami.FormData.label: i18n("Trigger notification when battery is below:")
+                            from: 0
+                            to: firstCaseNotificationSwitch.checked ? firstCaseBatteryLowSpin.value : 100
+                            stepSize: 5
+
+                            // Ensure second notification is always higher than the second one
+                            onValueModified: {
+                                if (firstCaseNotificationSwitch.checked && secondCaseBatteryLowSpin.value >= firstCaseBatteryLowSpin.value) {
+                                    errorMessagesLabel4.visible = true;
+                                    secondCaseBatteryLowSpin.value = secondCaseBatteryLowSpin.value - 5;
+                                } else {
+                                    errorMessagesLabel4.visible = false;
+                                    startTimer.running = false;
+                                }
+                            }
+                        }
+
+                        // Error message if second notification threshold is higher than first
+                        Label {
+                            id: errorMessagesLabel4
+                            visible: false
+                            anchors.left: parent.left
+                            text: i18n("Second case notification must be lower than the first one.")
+                            color: "red"
+                            font.bold: true
+
+                            // Start timer when error becomes visible (used for UI feedback)
+                            onVisibleChanged: {
+                                startTimer.running = true;
+                            }
+                        }
+                    }
+
+                    // Button to send a test notification for the second AirPods case
+                    Button {
+                        text: "Send test notification"
+                        enabled: secondCaseNotificationSwitch.checked
+                        onClicked: {
+                            sendBatteryNotification("AirPods Case", secondCaseBatteryLowSpin.value, secondCaseIconSwitch.checked, caseIconPath, secondCaseUrgencySwitch.checked);
+                        }
+                    }
+                }
+
+                // Update the ListModel description when the dialog is accepted
+                onAccepted: {
+                    setNotificationDescription(3, secondCaseNotificationSwitch, secondCaseBatteryLowSpin, secondCaseUrgencySwitch, secondCaseIconSwitch);
+                }
+            }
+
+            // Component used to create notifications dynamically
+            Component {
+                id: notificationComponent
+                Notification {
+                    componentName: Tools.existsNotifyrc() ? "airPodsBatteryWidget" : "plasma_workspace"
+                    eventId: "notification"
+                    autoDelete: true
+                }
+            }
+
+            // Timer to hide error messages after a short delay
+            Timer {
+                id: startTimer
+                interval: 3000
+                onTriggered: {
+                    errorMessagesLabel1.visible = errorMessagesLabel2.visible = errorMessagesLabel3.visible = errorMessagesLabel4.visible = false;
+                }
+            }
+        }
+    }  
+}

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -136,7 +136,8 @@ PlasmoidItem {
         
             // Row for average charge and case charge in the compact view
             RowLayout {
-                visible: cfg.averageView
+                id: averageView
+                visible: cfg.averageView || (cfg.autoView && (Math.abs(Tools.getLeftCharge() - Tools.getRightCharge()) <= 10))
                 spacing: 5
 
                 // AirPods charge display
@@ -188,7 +189,8 @@ PlasmoidItem {
 
             // Row for detailed charge view (left and right AirPods)
             RowLayout {
-                visible: cfg.detailedView
+                id: detailedView
+                visible: cfg.detailedView || (cfg.autoView && (Math.abs(Tools.getLeftCharge() - Tools.getRightCharge()) > 10))
                 spacing: 10
 
                 RowLayout {
@@ -271,9 +273,13 @@ PlasmoidItem {
                 updateChargeTextCompRep(leftCharge, Tools.getLeftCharge());
                 updateChargeTextCompRep(rightCharge, Tools.getRightCharge());
 
+                const averageViewValue = cfg.autoView ? (Math.abs(Tools.getLeftCharge() - Tools.getRightCharge()) <= 10) : cfg.averageView;
+                averageView.visible = averageViewValue;
+                detailedView.visible = !averageViewValue;
+
                 if (cfg.showCaseBattery && Tools.getCaseCharge() != -1) {
                     let caseChargeValue = Tools.getCaseCharge();
-                    if (cfg.averageView) {
+                    if (averageViewValue) {
                         updateChargeTextCompRep(caseCharge, caseChargeValue);
                         caseChargeLayout.visible = true;
                         caseChargeLayout.width = 65;
@@ -285,9 +291,9 @@ PlasmoidItem {
                         compactRep.Layout.minimumWidth = Kirigami.Units.iconSizes.large * 5.5;
                     }
                 } else {
-                    caseChargeLayout.visible = cfg.averageView ? false : caseChargeLayout1.visible = false;
+                    caseChargeLayout.visible = averageViewValue ? false : caseChargeLayout1.visible = false;
                     caseChargeLayout.width = 0;
-                    compactRep.Layout.minimumWidth = cfg.averageView ? Kirigami.Units.iconSizes.large * 2 : Kirigami.Units.iconSizes.large * 3.5;
+                    compactRep.Layout.minimumWidth = averageViewValue ? Kirigami.Units.iconSizes.large * 2 : Kirigami.Units.iconSizes.large * 3.5;
                 }
 
                 toolTipSubText = updateToolTip();

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -553,7 +553,7 @@ PlasmoidItem {
                     fullRep.Layout.minimumWidth = Kirigami.Units.gridUnit * 20
                     updateChargeTextCompFull(caseChargeText, caseChargeRaw);
                     renderAirpodCircle(circleCanvas3, caseChargeRaw, caseIconPath, isCaseCharging, cfg.iconWidthCaseFullRep, cfg.iconHeightCaseFullRep);
-                } else if (cfg.showAvailableCaseBatteryFullRep) {
+                } else if (cfg.showAvailableCaseBatteryFullRep || (cfg.autoHiddenCaseBatteryFullRep && !isLastCaseUpdateOld(cfg.customTimeThreshold3))) {
                     if (caseChargeRaw != -1) {
                         caseView.visible = true;
                         fullRep.Layout.minimumWidth = Kirigami.Units.gridUnit * 20

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -37,6 +37,18 @@ PlasmoidItem {
         intervalAlignment: P5Support.Types.AlignToMinute
     }
 
+    // Function to check if the last case update is older than a custom threshold
+    function isLastCaseUpdateOld(customTimeThreshold) {
+        var currentDateTime = new Date(dataSource.data.Local.DateTime); // First date
+        var lastCaseUpdated = Tools.getLastCaseUpdatedDate(); // Second date
+
+        // Convert milliseconds to hours
+        var diffInHours = (currentDateTime - lastCaseUpdated) / (1000 * 60 * 60);
+        return diffInHours > customTimeThreshold;
+
+        return false;
+    }
+
     // Function to update the icons
     function updateIcons() {
         if (cfg.autoWidgetIcons) {
@@ -165,7 +177,7 @@ PlasmoidItem {
                 // AirPods case charge display
                 RowLayout {
                     id: caseChargeLayout
-                    visible: cfg.showCaseBattery
+                    visible: cfg.showCaseBattery || cfg.autoHiddenCaseBattery
                     height: parent.height
                     width: childrenRect.width
                     spacing: 5
@@ -237,7 +249,7 @@ PlasmoidItem {
                 // AirPods case in detailed view
                 RowLayout {
                     id: caseChargeLayout1
-                    visible: cfg.showCaseBattery
+                    visible: cfg.showCaseBattery || cfg.autoHiddenCaseBattery
                     height: parent.height
                     width: childrenRect.width
                     spacing: 5
@@ -277,7 +289,7 @@ PlasmoidItem {
                 averageView.visible = averageViewValue;
                 detailedView.visible = !averageViewValue;
 
-                if (cfg.showCaseBattery && Tools.getCaseCharge() != -1) {
+                if ((cfg.showCaseBattery && Tools.getCaseCharge() != -1) || (cfg.autoHiddenCaseBattery && !isLastCaseUpdateOld(cfg.customTimeThreshold2))) {
                     let caseChargeValue = Tools.getCaseCharge();
                     if (averageViewValue) {
                         updateChargeTextCompRep(caseCharge, caseChargeValue);

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -496,7 +496,7 @@ PlasmoidItem {
                 visible: cfg.lastUpdateTextCheck
                 Text {
                     id: lastUpdated
-                    text: "Last updated: " + Tools.getLastUpdated()
+                    text: "Last updated: " + Qt.locale().toString(Tools.getLastUpdatedDate(), cfg.customDateFormat)
                     verticalAlignment: Text.AlignVCenter
                     font.pixelSize: cfg.fontSizeFullRepLU
                     font.bold: cfg.boldFullRepLU
@@ -556,7 +556,7 @@ PlasmoidItem {
                 }
 
                 // Update last update text
-                lastUpdated.text = "Last updated: " + Tools.getLastUpdated();
+                lastUpdated.text = "Last updated: " + Qt.locale().toString(Tools.getLastUpdatedDate(), cfg.customDateFormat);
 
                 toolTipSubText = updateToolTip();
                 updateIcons();

--- a/main.py
+++ b/main.py
@@ -76,6 +76,8 @@ def get_data():
     # On 7th position we can get AirPods model, gen1, gen2, Pro or Max
     if chr(raw[7]) == 'e':
         model = "AirPodsPro"
+    elif chr(raw[7]) == '4':
+        model = "AirPodsPro2"
     elif chr(raw[7]) == '3':
         model = "AirPods3"
     elif chr(raw[7]) == 'f':

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
         "ServiceTypes": [
             "Plasma/Applet"
         ],
-        "Version": "1",
+        "Version": "1.1.0",
         "Website": "https://github.com/Alessandros-Hube/airpods.battery.widget.frontend"
     },
     "X-Plasma-API-Minimum-Version": "6.0",

--- a/run.sh
+++ b/run.sh
@@ -2,11 +2,28 @@
 
 cd ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend
 
-python3 -m venv .
+python3 -m venv venv
 
-./bin/pip3 install -r requirements.txt
+# In version 1.0.1, the backend environment was created in the widget's root directory.
+# In the latest version, the environment is located inside the "venv" folder instead.
+# The following lines remove old environment files from the previous version.
+# These cleanup lines will be removed in future releases.
+
+old_venv_stuff=$(find ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/pyvenv.cfg 2>/dev/null)
+if [ -n "$old_venv_stuff" ]; then
+    rm -r bin
+    rm -r include
+    rm -r lib
+    rm -r lib64
+    rm -f pyvenv.cfg
+    echo "Remove old venv">&2 
+else
+    echo "fine">&2 
+fi
+
+./venv/bin/pip3 install -r requirements.txt
 
 while true; do
-    ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/bin/python3 ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/main.py ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/airstatus.out
+    ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/venv/bin/python3 ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/main.py ~/.local/share/plasma/plasmoids/airpods.battery.widget.frontend/airstatus.out
     sleep 30  # 30 seconds equals 1 minute
 done


### PR DESCRIPTION
This pull request prepares the next release of the AirPods Battery Widget with significant new features, improvements, and fixes.

**Features:**
- UI: Added customizable widget notifications (with new settings section)
- UI: Added new AirPods case full widget display options
- UI: Added new AirPods case panel display options
- UI: Added new AirPods panel display options with automatic switching
- UI: Added option to change the data format of the last update
- Device: Added support for AirPods Pro 2

**Fixes:**
- UI: Always display hidden widget in Plasma edit mode
- Core: Prevent potential RAM overflow when opening widget settings

**Refactor:**
- Simplified code and removed unnecessary DataSource component

**Chore:**
- Removed legacy virtual environment cleanup logic from v1.0.1